### PR TITLE
Flytter jakarta.jms-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 
         <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
+        <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
 
         <reflections.version>0.10.2</reflections.version>
 
@@ -105,6 +106,13 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jakarta.persistence.version}</version>
+            </dependency>
+
+            <dependency>
+                <!-- kan fjernes ved Jakarta EE 9/ oppgradering av jakarta.platform -->
+                <groupId>jakarta.jms</groupId>
+                <artifactId>jakarta.jms-api</artifactId>
+                <version>${jakarta.jms-api.version}</version>
             </dependency>
 
             <!-- WELD BOM -->


### PR DESCRIPTION
- Kan fjernes deretter fra fpsak og tilbake.