### PR TITLE
Break: swagger-ui brukes ikke lenger som dependency i prosjekter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
         <metrics.version>4.2.15</metrics.version>
 
         <swagger.version>2.2.8</swagger.version>
-        <swagger-ui.version>4.17.1</swagger-ui.version>
 
         <slf4j.version>2.0.6</slf4j.version>
         <logback.version>1.3.5</logback.version>
@@ -335,11 +334,6 @@
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core</artifactId>
                 <version>${swagger.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.webjars</groupId>
-                <artifactId>swagger-ui</artifactId>
-                <version>${swagger-ui.version}</version>
             </dependency>
 
             <!-- Test -->


### PR DESCRIPTION
Den brukes kun i k9-tilbake pga felles kodebase og ble flyttet direkte dit. 