### PR TITLE
Break: Fjerner graphql-java-codegen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,13 +165,6 @@
                 <type>pom</type>
             </dependency>
 
-            <!-- GraphQL -->
-            <dependency>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-java-codegen</artifactId>
-                <version>5.6.0</version>
-            </dependency>
-
             <!-- Kafka -->
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Brukes kun i fp-felles og vtp og ble flyttet dit.

Trenger å være kompatibel med maven-codegen-plugin også (se #351)