### PR TITLE
Tar med både smallrye og jboss jandex for omlegging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,10 +111,16 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- smallrye er standard for alle apps. beholder jboss pga andre bibliotek som drar inn den -->
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>jandex</artifactId>
+                <version>${jandex.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jandex</artifactId>
-                <version>${jandex.version}</version>
+                <version>3.1.6</version>
             </dependency>
 
             <!-- Jackson BOM -->


### PR DESCRIPTION
Tar med versjon av io.smallrye:jandex så applikasjonene kan legge om og unngå Warning
Beholder versjon av org.jboss:jandex for å overstyre versjoner som følger med andre bibliotek (Weld & co)