### PR TITLE
Revert "Bump com.fasterxml.jackson:jackson-bom from 2.16.2 to 2.17.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.17.0</version>
+                <version>2.16.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Reverts navikt/fp-bom#613 - Bør vente på 2.17.1 bla bytebuddy og BigDecimal