### PR TITLE
Jakarta EE10 variant av EL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <hibernate.version>6.4.4.Final</hibernate.version> <!-- 6.4.0.Final er buggy se HHH-17489 -->
 
-        <jakarta.el.version>4.0.2</jakarta.el.version>
+        <jakarta.el.version>5.0.0</jakarta.el.version>
         <swagger.version>2.2.21</swagger.version>
 
         <!-- maven jakarta kompatible plugins -->
@@ -397,10 +397,11 @@
                 <!-- oppdaterer versjon for å bli kvitt CVE-2023-34455 CVE-2023-34454 CVE-2023-34453 -->
                 <version>1.1.10.5</version>
             </dependency>
-            
+
+            <!-- brukes av hibernate-validator -->
             <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>jakarta.el</artifactId>
+                <groupId>org.glassfish.expressly</groupId>
+                <artifactId>expressly</artifactId>
                 <version>${jakarta.el.version}</version>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,52 +21,46 @@
         <sonar.organization>navikt</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-        <!-- Java Enterprise -->
+        <!-- Jakarta EE specifications -->
         <jakarta.jakartaee-bom.version>10.0.0</jakarta.jakartaee-bom.version>
 
+        <!-- Jakarta EE implementations -->
         <jetty.version>12.0.8</jetty.version>
         <jersey.version>3.1.6</jersey.version>
-
-        <logback.version>1.5.4</logback.version>
-
+        <jakarta.el.version>5.0.0</jakarta.el.version>
         <weld-core-bom.version>5.1.2.Final</weld-core-bom.version>
+        <jaxb-bom.version>4.0.5</jaxb-bom.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <hibernate.version>6.4.4.Final</hibernate.version>
 
+        <!-- Annet for WebApps -->
         <jandex-maven-plugin.version>3.1.7</jandex-maven-plugin.version>
         <jandex.version>3.1.7</jandex.version>
 
-        <jaxb-bom.version>4.0.5</jaxb-bom.version>
-
-        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-        <hibernate.version>6.4.4.Final</hibernate.version> <!-- 6.4.0.Final er buggy se HHH-17489 -->
-
-        <jakarta.el.version>5.0.0</jakarta.el.version>
         <swagger.version>2.2.21</swagger.version>
 
-        <!-- maven jakarta kompatible plugins -->
-        <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
-
-        <!-- Andre avhengigheter -->
-        <prometheus.version>0.16.0</prometheus.version>
         <micrometer.version>1.12.5</micrometer.version>
-        <metrics.version>4.2.15</metrics.version>
 
+        <logback.version>1.5.4</logback.version>
         <slf4j.version>2.0.12</slf4j.version>
         <logstash.version>7.4</logstash.version>
         <logback-syslog4j.version>1.0.0</logback-syslog4j.version>
 
-        <kafka.version>3.7.0</kafka.version> <!-- 3.6.0 logger excessive -->
+        <kafka.version>3.7.0</kafka.version>
 
         <hikari.version>5.1.0</hikari.version>
         <flyway.version>10.11.0</flyway.version>
         <postgresql.version>42.7.3</postgresql.version>
         <vault-jdbc.version>1.3.10</vault-jdbc.version>
 
+        <!-- Test versions -->
         <junit.version>5.10.2</junit.version>
         <assertj.version>3.25.3</assertj.version>
         <mockito.version>5.11.0</mockito.version>
-
         <reflections.version>0.10.2</reflections.version>
 
+        <!-- Build versions -->
+        <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     </properties>
 
@@ -227,15 +221,6 @@
                 <groupId>com.oracle.ojdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>19.3.0.0</version>
-            </dependency>
-
-            <!-- Metrics -->
-            <dependency>
-                <groupId>io.prometheus</groupId>
-                <artifactId>simpleclient_bom</artifactId>
-                <version>${prometheus.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
 
             <!-- Token validering -->


### PR DESCRIPTION
Brukes av hibernate-validator (provided dep til 5.0.0) )og jersey-bean-validation:3.1.6 (compile-dep til 5.0.0)
Jersey v3.1.5 brukte org.glassfish:jakarta.el:4.0.2
Er ikke sikker på om vi trenger inkludere denne eksplisitt (men for ordens skyld .....)