### PR TITLE
Ta med cdi-api i EE10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
                 <type>pom</type>
             </dependency>
 
+            <!-- TODO: Fjerne ved upgrade til EE11 da er den med i pakken -->
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>4.0.1</version>
+            </dependency>
             <!-- WELD BOM -->
             <dependency>
                 <groupId>org.jboss.weld</groupId>


### PR DESCRIPTION
Den er først inkludert i EE11 sin jakarta.jakartaee-bom - ikke i EE10. Kan fjernes over sommeren. Ikke merge 4.1.0