### PR TITLE
Fjerne compiler warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,11 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>1.17.5</version>
             </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>1.17.5</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.javassist</groupId>
@@ -513,6 +518,7 @@
                         <encoding>UTF-8</encoding>
                         <release>${java.version}</release>
                         <parameters>true</parameters>
+                        <proc>none</proc>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -559,7 +565,9 @@
                     <version>3.5.3</version>
                     <configuration>
                         <!-- Må ha @{argLine} ellers blir properties satt av jacoco-maven-plugin overkrevet -->
-                        <argLine>@{argLine} ${argLine}</argLine>
+                        <argLine>@{argLine} ${argLine}
+                            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+                        </argLine>
                     </configuration>
                 </plugin>
                 <!-- Kjører Databaseskjemainitialisering ved testing fra kommandolinja -->


### PR DESCRIPTION
Slår av javax.annotation.processing - ref maven-compiler-plugin/compile-mojo.html - brukes ikke og ser ikke behovet. 
Har testet lokalt med bygging av fpsak og fptilbake.
Overstyrer byte-buddy-agent med siste versjon siden Mockito drar inn en gammel (1.15)
Legger på loading av Mockito-agent i surefire-plugin
