### PR TITLE
Copilot: Oppdater med ref til fp-context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,14 +24,16 @@ applications and libraries.
 - All version pins live here. Downstream repos must not override versions.
 - Dependabot drives upgrades in this repo first; consumers pick them up on
   next bump.
-- Jakarta EE 11 baseline: Jetty, Jersey (server only), Weld CDI, Hibernate,
-  Jackson (migrating 2 → 3), Kafka 4.
-- Java 25.
+- Jakarta EE 11 baseline: Jetty, Jersey (server only), Weld CDI, Hibernate
+- Other: Jackson 2 (moving to Jackson 3), Kafka 4, flyway, Hikari, Database drivers.
+- Logging and Observability: SLF4J + logback and bridges, Prometheus + Micrometer, OpenTelemetry.
+- Test: JUnit 5, AssertJ, Mockito, Testcontainers.
+- Build: dependencies and common build-steps used downstream (e.g. release plugin)
+- Java 25+.
 
 Not in fp-bom:
 - JMS / IBM MQ — see `fp-jms-integrasjon`
-- token-support — only used by unicorns (`fp-infotrygd`, `fp-ws-proxy`)
-- No Spring Boot, no Ehcache
+- No Spring Boot or dependents like token-support
 
 ## When changing
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+# fp-bom
+
+Bill of Materials and parent POMs for all Team Foreldrepenger Java
+applications and libraries.
+
+## Context
+
+- [fp-context](https://github.com/navikt/fp-context) — team domain,
+  architecture, conventions. Source of truth.
+- Consumer view of this repo: see
+  [`architecture/team-libraries.md`](https://github.com/navikt/fp-context/blob/main/architecture/team-libraries.md).
+- Copilot Space: navikt / **TeamForeldrepenger**.
+
+## Structure
+
+| Module | Role |
+|--------|------|
+| `fp-bom` | The Bill of Materials (dependency versions only) |
+| `fp-parent-app` | Parent POM for deployable applications (build, plugin config, packaging) |
+| `fp-parent-lib` | Parent POM for libraries (build, plugin config, release) |
+
+## Conventions
+
+- All version pins live here. Downstream repos must not override versions.
+- Dependabot drives upgrades in this repo first; consumers pick them up on
+  next bump.
+- Jakarta EE 10 baseline (Jetty, Jersey, Weld, Hibernate, Jackson, IBM MQ).
+- Java 25.
+
+## When changing
+
+- Major version bumps: check breaking-change notes for downstream impact
+  (especially Jetty, Jersey, Weld, Hibernate, Jackson).
+- New dependencies: add only if used by ≥2 consumers; otherwise keep local.
+- Build/plugin changes in parent POMs affect all downstream — coordinate.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,14 @@ applications and libraries.
 - All version pins live here. Downstream repos must not override versions.
 - Dependabot drives upgrades in this repo first; consumers pick them up on
   next bump.
-- Jakarta EE 10 baseline (Jetty, Jersey, Weld, Hibernate, Jackson, IBM MQ).
+- Jakarta EE 11 baseline: Jetty, Jersey (server only), Weld CDI, Hibernate,
+  Jackson (migrating 2 → 3), Kafka 4.
 - Java 25.
+
+Not in fp-bom:
+- JMS / IBM MQ — see `fp-jms-integrasjon`
+- token-support — only used by unicorns (`fp-infotrygd`, `fp-ws-proxy`)
+- No Spring Boot, no Ehcache
 
 ## When changing
 


### PR DESCRIPTION
Add Copilot instructions referencing [fp-context](https://github.com/navikt/fp-context) (incl. the new `architecture/team-libraries.md`) and the **TeamForeldrepenger** Copilot Space.

Focuses on what's needed to maintain this library: internal structure, conventions, consumer-impact notes for changes.

Part of an ongoing effort to keep per-repo Copilot files token-efficient and free of duplication across the team's 40+ repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>